### PR TITLE
Only reboot if vmware tools is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,3 +61,4 @@
 
 - name: reboot after installation
   win_reboot:
+  when: not vmware_tools_install.stat.exists


### PR DESCRIPTION
At the moment, the server(s) reboot after being checked instead of just when vmware tools is installed. 